### PR TITLE
Fix label type in validation script

### DIFF
--- a/validate.php
+++ b/validate.php
@@ -18,7 +18,7 @@ $samples = $labels = [];
 for ($label = 0; $label < 10; $label++) {
     foreach (glob("testing/$label/*.png") as $file) {
         $samples[] = [imagecreatefrompng($file)];
-        $labels[] = $label;
+        $labels[] = (string) $label;
     }
 }
 


### PR DESCRIPTION
Perform explicit typecast on `$label` variable prior to pushing it into `$labels[]` array.